### PR TITLE
[codex] Allow transaction month with resource filters

### DIFF
--- a/index.js
+++ b/index.js
@@ -551,6 +551,16 @@ function allHistorySinceDate() {
   return "1970-01-01";
 }
 
+function endOfMonth(month) {
+  const match = /^(\d{4})-(\d{2})-01$/.exec(month);
+  if (!match) {
+    throw new Error("month must be in YYYY-MM-DD format and use the first day of the month.");
+  }
+  const year = Number(match[1]);
+  const monthIndex = Number(match[2]) - 1;
+  return new Date(Date.UTC(year, monthIndex + 1, 0)).toISOString().slice(0, 10);
+}
+
 function buildTransactionListPath({ budgetId, accountId, categoryId, payeeId, month }) {
   const bid = pathSegment(resolveBudgetId(budgetId));
   if (accountId) return `/plans/${bid}/accounts/${pathSegment(accountId)}/transactions`;
@@ -571,10 +581,15 @@ async function fetchTransactions({
   month,
   lastKnowledgeOfServer,
 }) {
-  return ynabFetch(buildTransactionListPath({ budgetId, accountId, categoryId, payeeId, month }), {
+  const hasResourceFilter = Boolean(accountId || categoryId || payeeId);
+  const effectiveMonth = hasResourceFilter ? undefined : month;
+  const effectiveSinceDate = month && hasResourceFilter ? month : sinceDate;
+  const effectiveUntilDate = month && hasResourceFilter ? endOfMonth(month) : untilDate;
+
+  return ynabFetch(buildTransactionListPath({ budgetId, accountId, categoryId, payeeId, month: effectiveMonth }), {
     query: {
-      since_date: sinceDate,
-      until_date: untilDate,
+      since_date: effectiveSinceDate,
+      until_date: effectiveUntilDate,
       type,
       last_knowledge_of_server: lastKnowledgeOfServer,
     },
@@ -1491,7 +1506,7 @@ function formatTransaction(t) {
 
 registerTool(
   "get_transactions",
-  { description: "Get transactions with optional filters. Use type='unapproved' or type='uncategorized' to filter. Optionally filter by account, category, payee, or month. Each returned transaction includes 'import_payee_name_original' — the raw merchant string from the bank import (e.g. 'AplPay LS ONION RIVEMONTPELIER VT') — which encodes processor flag, merchant name (often longer than the cleaned payee_name), and city+state. This is the primary disambiguation field when payee_name is truncated or ambiguous. YNAB now defaults omitted sinceDate to one year ago; pass an explicit older sinceDate to retrieve older history. Note: large date ranges (6+ months on a busy budget) can return 50KB+ of data; narrow with categoryId/payeeId/month/sinceDate/untilDate filters when possible.", inputSchema: {
+  { description: "Get transactions with optional filters. Use type='unapproved' or type='uncategorized' to filter. Optionally filter by account, category, payee, or month. You may combine one of accountId/categoryId/payeeId with month to fetch that resource's transactions for a specific month. Each returned transaction includes 'import_payee_name_original' — the raw merchant string from the bank import (e.g. 'AplPay LS ONION RIVEMONTPELIER VT') — which encodes processor flag, merchant name (often longer than the cleaned payee_name), and city+state. This is the primary disambiguation field when payee_name is truncated or ambiguous. YNAB now defaults omitted sinceDate to one year ago; pass an explicit older sinceDate to retrieve older history. Note: large date ranges (6+ months on a busy budget) can return 50KB+ of data; narrow with categoryId/payeeId/month/sinceDate/untilDate filters when possible.", inputSchema: {
     budgetId: z.string().optional().describe("Budget ID (uses default if not provided)"),
     sinceDate: z.string().optional().describe("Only return transactions on or after this date (YYYY-MM-DD). If omitted, YNAB defaults to one year ago."),
     untilDate: z.string().optional().describe("Only return transactions on or before this date (YYYY-MM-DD)"),
@@ -1504,9 +1519,12 @@ registerTool(
   } },
   ({ budgetId, sinceDate, untilDate, type, accountId, categoryId, payeeId, month, lastKnowledgeOfServer }) =>
     run(async () => {
-      const resourceFilters = [accountId, categoryId, payeeId, month].filter((value) => value !== undefined && value !== null && value !== "");
+      const resourceFilters = [accountId, categoryId, payeeId].filter((value) => value !== undefined && value !== null && value !== "");
       if (resourceFilters.length > 1) {
-        throw new Error("Provide only one of accountId, categoryId, payeeId, or month.");
+        throw new Error("Provide only one of accountId, categoryId, or payeeId. You may combine one of these with month.");
+      }
+      if (month && (sinceDate || untilDate)) {
+        throw new Error("Provide either month or sinceDate/untilDate, not both.");
       }
 
       const data = await fetchTransactions({

--- a/test.js
+++ b/test.js
@@ -297,9 +297,60 @@ await test("get_transactions (by category)", async () => {
   if (!Array.isArray(txns)) throw new Error("not an array");
 });
 
+await test("get_transactions (by category and month)", async () => {
+  const byMonth = await call("get_transactions", { budgetId: bid, categoryId: testCatId, month: testMonth });
+  if (!Array.isArray(byMonth)) throw new Error("not an array");
+  for (const t of byMonth) {
+    if (t.category_id !== testCatId) throw new Error(`unexpected category ${t.category_id}`);
+    if (!t.date.startsWith(testMonthLabel)) throw new Error(`unexpected date ${t.date}`);
+  }
+
+  const [year, month] = testMonthLabel.split("-").map(Number);
+  const untilDate = new Date(Date.UTC(year, month, 0)).toISOString().slice(0, 10);
+  const byDateRange = await call("get_transactions", {
+    budgetId: bid,
+    categoryId: testCatId,
+    sinceDate: testMonth,
+    untilDate,
+  });
+  const monthIds = byMonth.map((t) => t.id).sort();
+  const dateRangeIds = byDateRange.map((t) => t.id).sort();
+  if (JSON.stringify(monthIds) !== JSON.stringify(dateRangeIds)) {
+    throw new Error("category+month did not match category+date-range results");
+  }
+});
+
+await test("get_transactions (by account and month)", async () => {
+  const txns = await call("get_transactions", { budgetId: bid, accountId: testAccountId, month: testMonth });
+  if (!Array.isArray(txns)) throw new Error("not an array");
+  for (const t of txns) {
+    if (t.account_id !== testAccountId) throw new Error(`unexpected account ${t.account_id}`);
+    if (!t.date.startsWith(testMonthLabel)) throw new Error(`unexpected date ${t.date}`);
+  }
+});
+
 await test("get_transactions (by payee)", async () => {
   const txns = await call("get_transactions", { budgetId: bid, payeeId: testPayeeId, sinceDate: "2026-01-01" });
   if (!Array.isArray(txns)) throw new Error("not an array");
+});
+
+await test("get_transactions (by payee and month)", async () => {
+  const txns = await call("get_transactions", { budgetId: bid, payeeId: testPayeeId, month: testMonth });
+  if (!Array.isArray(txns)) throw new Error("not an array");
+  for (const t of txns) {
+    if (t.payee_id !== testPayeeId) throw new Error(`unexpected payee ${t.payee_id}`);
+    if (!t.date.startsWith(testMonthLabel)) throw new Error(`unexpected date ${t.date}`);
+  }
+});
+
+await test("get_transactions rejects month with explicit date range", async () => {
+  try {
+    await call("get_transactions", { budgetId: bid, categoryId: testCatId, month: testMonth, sinceDate: testMonth });
+  } catch (e) {
+    if (!e.message.includes("either month or sinceDate/untilDate")) throw e;
+    return;
+  }
+  throw new Error("expected validation error");
 });
 
 await test("get_transaction (single)", async () => {


### PR DESCRIPTION
## Summary

- allow `get_transactions` to combine `month` with one of `accountId`, `categoryId`, or `payeeId`
- translate resource+month requests into resource-scoped transaction endpoints with `since_date`/`until_date`
- reject ambiguous `month + sinceDate/untilDate` inputs
- add tests for category/account/payee + month behavior

## Why

Natural transaction lookups often need both a resource scope and a month, e.g. “transactions in category X for April 2026”. Previously the MCP rejected this with “Provide only one of accountId, categoryId, payeeId, or month,” forcing callers to over-fetch or bypass the MCP.

## Test Plan

- targeted live smoke test against patched MCP server:

```json
{
  "categoryMonthCount": 32,
  "categoryRangeCount": 32,
  "accountMonthCount": 44,
  "validationRejection": true
}
```

- `npm run test:safety`

```text
Safety model checks passed
```