### PR TITLE
fix: make tool responses describe what they actually contain

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,8 +371,10 @@ Beyond tools, the server ships **6 MCP prompts** (guided workflows: monthly revi
 - **Bulk operations** - `create_transactions` and `update_transactions` handle arrays in a single API call. Bulk updates can look transactions up by `id` or by `importId`.
 - **Verified batch updates** - `update_transactions` refetches the whole batch in a single list request after the bulk API call (instead of one request per transaction, which used to consume the shared rate budget on large batches), retries mismatched fields once through single-transaction updates, and returns a `verification` block so approval counts cannot hide failed category writes.
 - **Fetch-then-merge updates** - scheduled transaction updates (which use PUT semantics) automatically fetch the current state and merge your changes, so you only specify what changed.
-- **Fuzzy search** - `search_categories` and `search_payees` do case-insensitive partial matching across all entries.
+- **Fuzzy search** - `search_categories` and `search_payees` do case-insensitive partial matching across all entries. Category search covers both the category name and its group name, tokenizes multi-word queries and OR-matches them (so `gym fitness membership` still lands), ranks whole-phrase and name hits above single-token and group-only hits, and reports `matched_on` / `matched_terms` per result. It does no synonym expansion — an empty result says so and points at `list_categories`.
+- **Decoded text** - YNAB stores some strings HTML-escaped (bank imports are the usual source). Names, memos and notes are entity-decoded on the way out, so a payee reads as `B&H Photo Video` rather than `B&amp;H Photo Video`, and name search matches either spelling. Writes send exactly what the caller supplied.
 - **Approval workflow with anomaly flags** - `review_unapproved` scans the full transaction history for unapproved entries (YNAB's API defaults to the last year, which would silently hide older stragglers) and groups transactions into "ready to approve" (categorized, split, or transfer) and "needs attention" (uncategorized), and attaches a `flags` array to each transaction surfacing anomalies: `manually_entered` (not bank-imported), `match_broken` (stale match reference), `scheduled_transaction_realized`, `new_payee`, `no_prior_amount_match` (novel amount for this payee), and `category_drift:was_X` (payee categorized differently in the prior 60 days). Group-level flags aggregate the union of all transaction flags. Bulk approval requires `confirmed: true`.
+- **Honest group headers** - a `by_payee` group describes all of its rows, not just the first one. Groups carry `category_names` (every distinct category in the group) plus `mixed_categories`, and `category_name` is `null` whenever the group spans more than one category. `total` is the net; a group whose rows run both directions also carries `mixed_amount_signs: true` with `inflow_total` and `outflow_total`, so a net that nets refunds against charges cannot be read as a single small charge.
 - **Nullable updates** - update tools accept `null` for clearable fields (`memo`, `payeeName`, `categoryId`, `flagColor`) to distinguish "don't change" (omit) from "clear this field" (`null`).
 - **Target behavior support** - category create/update tools expose `goalNeedsWholeAmount` for YNAB's "Set aside another" vs. "Refill up to" goal behavior.
 - **Delta request support** - high-volume list tools accept `lastKnowledgeOfServer` and return `server_knowledge` when that parameter is provided. `get_budget` supports full delta exports: pass `lastKnowledgeOfServer` to receive every entity changed since that knowledge in one response.
@@ -418,7 +420,7 @@ Read tools are available by default. Tools that create, update, import, or delet
 | `create_category` | Write tool: create a new category in an existing group (with optional goal) |
 | `create_category_group` | Write tool: create a new category group |
 | `update_category_group` | Write tool: rename a category group |
-| `search_categories` | Case-insensitive partial name search (e.g., "groc" finds "Groceries") |
+| `search_categories` | Case-insensitive partial name search over category names **and** category-group names (e.g., "groc" finds "Groceries"; "health" finds everything in a "Health & Medical" group). Multi-word queries are tokenized and OR-matched, results are ranked, and each result reports `matched_on` / `matched_terms`. Pass `includeHidden: true` to search hidden categories and groups. |
 
 ### Payees
 
@@ -462,8 +464,8 @@ Read tools are available by default. Tools that create, update, import, or delet
 | `get_transaction` | Get a single transaction by ID (includes subtransactions). Auto-handles composite scheduled-transaction IDs like `uuid_YYYY-MM-DD`; if the underlying matched transaction has been deleted, falls back to returning the active scheduled template wrapped as `{ resource_type: "scheduled_transaction", ... }`. |
 | `create_transaction` | Write tool: create a transaction with optional split (subtransactions must sum to total) |
 | `create_transactions` | Write tool: bulk create multiple transactions in a single API call (supports split transactions) |
-| `update_transaction` | Write tool: partial update - only specified fields change. Can convert a non-split transaction into a split via `subtransactions`. |
-| `update_transactions` | Write tool: batch update multiple transactions at once (look up each entry by `id` or `importId`), then verify requested fields persisted using a single batch refetch. Pass `returnSummary: true` for compact counts instead of full objects on large batches (avoids overflowing the tool-result size limit). |
+| `update_transaction` | Write tool: partial update - only specified fields change. Can convert a non-split transaction into a split via `subtransactions`. Composite scheduled-transaction IDs (`uuid_YYYY-MM-DD`) are writable — see below. |
+| `update_transactions` | Write tool: batch update multiple transactions at once (look up each entry by `id` or `importId`), then verify requested fields persisted using a single batch refetch. Returns `newly_approved_count` beside `approved_count`. Pass `returnSummary: true` for compact counts instead of full objects on large batches (avoids overflowing the tool-result size limit). |
 | `approve_transactions` | Write tool: approve unapproved transactions in bulk by filter (`payeeId` / `categoryId` / `accountId`) without hand-listing IDs. Skips uncategorized transactions by default, requires `confirmed: true`, and supports `expectedMatchedCount`. |
 | `reassign_payee_transactions` | Write tool: move all transactions from one payee to another, the merge workaround since the YNAB API has no payee delete/merge endpoint. Requires `confirmed: true` and supports `expectedMatchedCount`. |
 | `delete_transaction` | Write tool: delete a transaction. Requires `confirmed: true`. |
@@ -485,7 +487,7 @@ Read tools are available by default. Tools that create, update, import, or delet
 
 | Tool | Description |
 |------|-------------|
-| `review_unapproved` | Get unapproved transactions grouped by readiness: "ready to approve" (categorized, split, or transfer) vs. "needs category first" (uncategorized). Each transaction includes a `flags` array highlighting anomalies (manually_entered, match_broken, no_prior_amount_match, category_drift, new_payee, scheduled_transaction_realized) computed against 60 days of payee history. Includes a warning against blind approval. Pass `summary: true` for counts + by-payee aggregates only, or `compact: true` to keep per-transaction rows (with IDs) while dropping bulky fields so the response fits inline. |
+| `review_unapproved` | Get unapproved transactions grouped by readiness: "ready to approve" (categorized, split, or transfer) vs. "needs category first" (uncategorized). Each transaction includes a `flags` array highlighting anomalies (manually_entered, match_broken, no_prior_amount_match, category_drift, new_payee, scheduled_transaction_realized) computed against 60 days of payee history. Group headers report `category_names` / `mixed_categories` and, when the rows run both directions, `inflow_total` / `outflow_total` beside the net `total`. Includes a warning against blind approval. Pass `summary: true` for counts + by-payee aggregates only, or `compact: true` to keep per-transaction rows (with IDs) while dropping bulky fields so the response fits inline — `match_broken` rows keep `matched_transaction_id` in compact mode, since triaging that flag means looking the matched id up. |
 | `get_overspent_categories` | Get categories with negative balances for a month, useful for finding prior-month overspending that reduces the current month's Ready to Assign. |
 
 ### Workflows (v4.0)
@@ -557,6 +559,26 @@ When a batch operation categorizes and approves transactions at the same time, d
 ```
 
 Treat any `failed` entry as a real write failure and inspect the named transaction with `get_transaction`.
+
+#### Approval counts
+
+Batch responses report two different approval numbers, and only one of them answers "what did this call approve?":
+
+```json
+{
+  "updated_count": 9,
+  "approved_count": 3,
+  "newly_approved_count": 1,
+  "already_approved_count": 2,
+  "approval_state_unknown_count": 0
+}
+```
+
+`approved_count` is how many rows in the batch are approved **now**, including rows that were already approved when the batch was submitted. `newly_approved_count` is how many rows this call actually flipped, measured against the pre-write fetch; `already_approved_count` and `approval_state_unknown_count` (no before-state available, e.g. an `importId` row whose refetch failed) account for the rest. Report `newly_approved_count` to a user. `approve_transactions` only ever touches rows that were unapproved when it fetched them, so there the two are equal.
+
+### Composite Scheduled-Transaction IDs
+
+A scheduled transaction that has realized carries a composite ID of the form `d9e7c3c2-…_2026-07-30` (the shape `review_unapproved` flags as `scheduled_transaction_realized`). The suffix makes the ID look synthetic, and the natural assumption is that such a row is read-only or that the suffix must be stripped before writing. Neither is true: pass the ID exactly as returned and `update_transaction` / `update_transactions` apply memo, category and approval to the realized transaction, returning the full updated object. Reads are equally forgiving — `get_transaction` strips the suffix itself and falls back to the scheduled template when the underlying matched transaction has been deleted.
 
 ### Credit Card Payment Transfers
 

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -1,5 +1,70 @@
 # Worklog
 
+## 2026-08-05 - Fixed seven connector findings from a live triage session
+
+**Context**: A live session using the hosted connector produced eight findings.
+Seven were defects; the eighth (`audit_account_reconciliation`) was a compliment
+and needed no change. The common thread across the defects is a response that a
+model can read correctly and still describe wrongly to a user.
+
+**Group headers described one row, not the group**: `review_unapproved` built
+each `by_payee` group header from the first transaction in it. A Venmo group
+reported `category_name: "🏖️ Cuttyhunk"` while three of its four rows were
+🚲 eBike. Groups now carry `category_names` (every distinct category) and
+`mixed_categories`; `category_name` is null whenever the group is mixed, so
+there is no single-category field left to quote for a group that has no single
+category. The same failure applied to `total`: an Adobe group reported
+`-12.83`, a plausible-looking small charge that was really five rows including
+two positive reversals. A group whose rows run both directions now reports
+`mixed_amount_signs: true` with `inflow_total` and `outflow_total` beside the
+net.
+
+**`approved_count` answered a different question than the one asked**: it
+counted rows that *end* approved, so a nine-row batch with one `approved: true`
+returned `approved_count: 3` because two rows arrived already approved.
+Reporting that to a user is a factual error about what the call did.
+`update_transactions` now returns `newly_approved_count`,
+`already_approved_count` and `approval_state_unknown_count` alongside it,
+measured against the before-state fetch the undo journal already performs — no
+extra API requests. `approve_transactions` reports the same field names, where
+the two counts are necessarily equal because it only touches rows that were
+unapproved when it fetched them.
+
+**`compact: true` dropped the field its own triage requires**: the tool
+description tells a model to GET `matched_transaction_id` to triage a
+`match_broken` flag, and compact mode dropped that id along with the other
+match/import fields. Compact rows now keep it, but only for rows carrying the
+flag, so the size saving survives for everything else.
+
+**`search_categories` could not answer multi-word queries and searched only
+names**: `gym fitness membership` returned nothing while `gym` worked. Queries
+are now tokenized and OR-matched over both the category name and its group
+name, ranked (whole-phrase above token, name above group), and each result
+reports `matched_on` / `matched_terms` so a group-only hit is not mistaken for
+a name hit. Worth being precise about the limit: group search does *not* make
+`gym` find `🏊‍♂️ GMCF Membership` in the "Health & Medical" group — no word is
+shared and this does no synonym expansion. What finds it is the tokenized
+query. The empty-result message now says exactly that and points at
+`list_categories`.
+
+**HTML entities reached the user**: a payee read as `B&amp;H Photo Video`.
+Decoding happens once, in `ok()`, over an allow-list of name/memo/note fields,
+so no per-tool formatter can forget it and no id, date or raw CSV payload is
+touched. Name search normalizes both sides, so `B&H` and `B&amp;H` behave
+identically. Writes still send exactly what the caller supplied.
+
+**Composite scheduled IDs are writable, which the format actively hides**:
+`d9e7c3c2-…_2026-07-30` accepted a memo, a category and approval and returned a
+full object. The suffix invites the opposite assumption, so this is now stated
+in `update_transaction`, in the `scheduled_transaction_realized` row of the
+flags reference, and in the README.
+
+**Verification**: 45 offline unit tests pass (17 new), 25 Worker tests pass,
+the safety-model check passes, and release consistency passes. The tool
+responses were also exercised end to end through an in-memory MCP client
+against stubbed YNAB payloads reproducing the exact Venmo, Adobe and B&amp;H
+rows from the findings.
+
 ## 2026-07-30 - Found why Claude showed the wrong connector icon
 
 **Context**: Resolves the 2026-07-17 investigation, which ended undecided, and

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -65,6 +65,20 @@ responses were also exercised end to end through an in-memory MCP client
 against stubbed YNAB payloads reproducing the exact Venmo, Adobe and B&amp;H
 rows from the findings.
 
+**Unrelated CI failure fixed in the same PR**: the `security` job went red on
+`npm audit --audit-level=high` for reasons that predate this branch — main last
+ran green on 2026-07-31 and the advisories (`fast-uri` GHSA-7p8r-x3mc-p8w7,
+`ip-address` GHSA-mwp4-54f8-5fhr and two siblings, `hono`
+GHSA-8j4g-w8fx-2239) published after it. Reproduced locally on an unmodified
+`package-lock.json`, so it is not caused by the code change. `fast-uri` has no
+fixed 3.x, so the override moves to `4.1.2` across ajv's `^3.0.1` range; the
+existing pin at `3.1.4` was itself inside the vulnerable range. `ip-address`
+and `hono` move within range. Both root and Worker manifests are updated, and
+both audits now report zero. The Worker lockfile diff also drops `libc`
+metadata on sharp's optional dev binaries — an artifact of the npm that
+regenerated it, functionally inert, and `npm ci` was rerun from clean in both
+packages to confirm.
+
 ## 2026-07-30 - Found why Claude showed the wrong connector icon
 
 **Context**: Resolves the 2026-07-17 investigation, which ended undecided, and

--- a/index.js
+++ b/index.js
@@ -498,6 +498,83 @@ function withCurrencyFields(out, source, fields) {
   return out;
 }
 
+// ==================== Text decoding ====================
+// YNAB stores several human-readable strings HTML-escaped (bank imports are the
+// usual source), so a payee arrives as "B&amp;H Photo Video". Nothing downstream
+// renders HTML — the value is read by a model and repeated to a user — so the
+// escaping is pure noise that also breaks substring search ("B&H" never matches
+// "B&amp;H"). Decoding happens on the way out only; writes send exactly what the
+// caller supplied.
+const NAMED_HTML_ENTITIES = {
+  amp: "&", lt: "<", gt: ">", quot: '"', apos: "'", nbsp: " ",
+  ndash: "–", mdash: "—", hellip: "…", middot: "·", bull: "•",
+  lsquo: "‘", rsquo: "’", ldquo: "“", rdquo: "”",
+  copy: "©", reg: "®", trade: "™", deg: "°",
+  eacute: "é", egrave: "è", agrave: "à", ccedil: "ç",
+  ntilde: "ñ", uuml: "ü", ouml: "ö", auml: "ä",
+};
+
+function decodeHtmlEntities(value) {
+  if (typeof value !== "string" || !value.includes("&")) return value;
+  return value.replace(/&(#[0-9]+|#x[0-9a-f]+|[a-z][a-z0-9]*);/gi, (match, body) => {
+    if (body[0] === "#") {
+      const code = body[1] === "x" || body[1] === "X"
+        ? Number.parseInt(body.slice(2), 16)
+        : Number.parseInt(body.slice(1), 10);
+      // Reject lone surrogates and out-of-range code points rather than
+      // producing an unpaired surrogate that breaks JSON serialization.
+      if (!Number.isInteger(code) || code < 0 || code > 0x10ffff) return match;
+      if (code >= 0xd800 && code <= 0xdfff) return match;
+      return String.fromCodePoint(code);
+    }
+    const named = NAMED_HTML_ENTITIES[body.toLowerCase()];
+    return named === undefined ? match : named;
+  });
+}
+
+// Only human-readable name/memo fields are decoded. IDs, dates, enum values and
+// raw CSV payloads are left byte-for-byte alone.
+const DECODED_TEXT_FIELDS = new Set([
+  "name", "payee", "payee_name", "category_name", "account_name", "group",
+  "group_name", "category_group_name", "original_category_group_name",
+  "memo", "note", "flag_name", "import_payee_name", "import_payee_name_original",
+  "transfer_account_name", "from_payee_name", "to_payee_name",
+]);
+
+// Walks a freshly-built tool payload in place (no clone: these objects are
+// constructed per response and never shared) and decodes the allow-listed
+// fields wherever they appear, including inside arrays and nested groups.
+function decodeTextFieldsDeep(value, seen) {
+  if (value === null || typeof value !== "object") return value;
+  const visited = seen || new Set();
+  if (visited.has(value)) return value;
+  visited.add(value);
+  if (Array.isArray(value)) {
+    for (const item of value) decodeTextFieldsDeep(item, visited);
+    return value;
+  }
+  for (const key of Object.keys(value)) {
+    const child = value[key];
+    if (typeof child === "string") {
+      // Assign only on an actual change: some payloads embed objects owned by
+      // the runtime config, and an untouched string must stay untouched.
+      if (DECODED_TEXT_FIELDS.has(key)) {
+        const decoded = decodeHtmlEntities(child);
+        if (decoded !== child) value[key] = decoded;
+      }
+    } else if (child !== null && typeof child === "object") {
+      decodeTextFieldsDeep(child, visited);
+    }
+  }
+  return value;
+}
+
+// Case- and entity-insensitive haystack for name matching, so a query typed
+// either way ("B&H" or "B&amp;H") hits the same rows.
+function normalizeSearchText(value) {
+  return decodeHtmlEntities(value ?? "").toLowerCase().replace(/\s+/g, " ").trim();
+}
+
 const subtransactionInputSchema = z.object({
   amount: z.number().describe("Subtransaction amount in dollars"),
   categoryId: z.string().optional().describe("Category ID"),
@@ -684,6 +761,30 @@ async function verifyBulkTransactionUpdates(budgetId, requestedUpdates, response
   return { verification, verified: results.map((r) => r.refetched) };
 }
 
+// Approval accounting for batch writes. "How many are approved now" and "how
+// many did this call approve" are different numbers whenever the batch contains
+// rows that were already approved, and only the second one can be reported to a
+// user as the result of their request. The before-states come from the
+// pre-write fetch; rows with no before-state are counted separately rather than
+// guessed at. verifiedTransactions is index-aligned with requestedUpdates.
+function summarizeApprovalChanges(requestedUpdates, beforeById, verifiedTransactions) {
+  const counts = {
+    approved_count: 0,
+    newly_approved_count: 0,
+    already_approved_count: 0,
+    approval_state_unknown_count: 0,
+  };
+  requestedUpdates.forEach((requested, i) => {
+    if (!verifiedTransactions[i]?.approved) return;
+    counts.approved_count += 1;
+    const before = beforeById?.get(normalizeTransactionId(requested?.id ?? ""));
+    if (!before) counts.approval_state_unknown_count += 1;
+    else if (before.approved) counts.already_approved_count += 1;
+    else counts.newly_approved_count += 1;
+  });
+  return counts;
+}
+
 // YNAB scheduled transactions that realize get composite IDs like `uuid_YYYY-MM-DD`.
 // Strip the date suffix so API lookups work correctly.
 function normalizeTransactionId(id) {
@@ -696,6 +797,9 @@ function normalizeTransactionId(id) {
 const PRETTY_PRINT_MAX_BYTES = 65536;
 
 function ok(data) {
+  // Single choke point for entity decoding: every tool returns through ok(),
+  // so no per-tool formatter can forget it.
+  decodeTextFieldsDeep(data);
   const compact = JSON.stringify(data);
   const text = compact.length > PRETTY_PRINT_MAX_BYTES ? compact : JSON.stringify(data, null, 2);
   const content = [{ type: "text", text }];
@@ -2108,9 +2212,9 @@ registerTool(
 
 registerTool(
   "update_transaction",
-  { description: "Update an existing transaction. Only provided fields are changed. Amounts in dollars. Passing subtransactions converts a non-split transaction into a split. This works on bank-imported transactions too, including reconciled ones, and preserves import_id — reach for prepare_split_for_matching only if this actually errors. What is NOT supported is changing an existing split: the API rejects that, and setting categoryId on the parent does not collapse it. Un-split in the YNAB web register first (select the row → Categorize → pick one category → confirm the un-split dialog), then call this.", inputSchema: {
+  { description: "Update an existing transaction. Only provided fields are changed. Amounts in dollars. Composite scheduled-transaction IDs (uuid_YYYY-MM-DD, the shape review_unapproved flags as scheduled_transaction_realized) are WRITABLE despite looking synthetic: pass the id exactly as returned and memo, category, approval and the rest apply to the realized transaction, which is returned in full. Do not strip the date suffix yourself and do not assume such a row is read-only. Passing subtransactions converts a non-split transaction into a split. This works on bank-imported transactions too, including reconciled ones, and preserves import_id — reach for prepare_split_for_matching only if this actually errors. What is NOT supported is changing an existing split: the API rejects that, and setting categoryId on the parent does not collapse it. Un-split in the YNAB web register first (select the row → Categorize → pick one category → confirm the un-split dialog), then call this.", inputSchema: {
     budgetId: z.string().optional().describe("Budget ID (uses default if not provided)"),
-    transactionId: z.string().describe("Transaction ID"),
+    transactionId: z.string().describe("Transaction ID. Composite scheduled-transaction IDs (uuid_YYYY-MM-DD) are accepted verbatim and are writable."),
     accountId: z.string().optional().describe("Account ID"),
     date: z.string().optional().describe("Transaction date (YYYY-MM-DD)"),
     amount: z.number().optional().describe("Amount in dollars"),
@@ -2173,7 +2277,7 @@ registerTool(
 
 registerTool(
   "update_transactions",
-  { description: "Batch update multiple transactions. Each transaction object must include its id and the fields to update. IMPORTANT: only use transaction IDs extracted from get_transactions / review_unapproved results — never compose IDs by hand (fabricated IDs return 'transaction does not exist in this budget' errors). For combined category+approval changes, include both 'categoryId' and 'approved: true' in the same entry. This tool refetches each transaction after the bulk update, verifies requested fields actually persisted, and retries mismatches once through single-transaction updates. Never trust review_unapproved counts alone after approving transactions; use this response's verification block or get_transaction to confirm fields.", inputSchema: {
+  { description: "Batch update multiple transactions. Each transaction object must include its id and the fields to update. IMPORTANT: only use transaction IDs extracted from get_transactions / review_unapproved results — never compose IDs by hand (fabricated IDs return 'transaction does not exist in this budget' errors). For combined category+approval changes, include both 'categoryId' and 'approved: true' in the same entry. This tool refetches each transaction after the bulk update, verifies requested fields actually persisted, and retries mismatches once through single-transaction updates. Never trust review_unapproved counts alone after approving transactions; use this response's verification block or get_transaction to confirm fields. APPROVAL COUNTS: approved_count is how many rows in the batch are approved NOW (including rows that arrived already approved); newly_approved_count is how many this call actually flipped from unapproved to approved, with already_approved_count and approval_state_unknown_count (before-state unavailable) accounting for the difference. Report newly_approved_count to a user as 'what was approved' — approved_count overstates it.", inputSchema: {
     budgetId: z.string().optional().describe("Budget ID (uses default if not provided)"),
     transactions: z
       .array(
@@ -2194,7 +2298,7 @@ registerTool(
         })
       )
       .describe("Array of transaction updates"),
-    returnSummary: z.boolean().optional().describe("If true, return compact counts (updated_count, approved_count, and verification counts) instead of the full updated-transaction objects. Use for large batches (~50+) whose full response would exceed the inline tool-result limit; the write is performed identically either way."),
+    returnSummary: z.boolean().optional().describe("If true, return compact counts (updated_count, the approval counts, and verification counts) instead of the full updated-transaction objects. Use for large batches (~50+) whose full response would exceed the inline tool-result limit; the write is performed identically either way."),
   } },
   ({ budgetId, transactions: txns, returnSummary }) =>
     run(async () => {
@@ -2254,10 +2358,11 @@ registerTool(
           isError: true,
         };
       }
+      const approval = summarizeApprovalChanges(resolved, beforeById, verified);
       if (returnSummary) {
         return ok({
           updated_count: verified.length,
-          approved_count: verified.filter((t) => t.approved).length,
+          ...approval,
           duplicate_import_ids: data.duplicate_import_ids,
           verification: {
             checked: verification.checked,
@@ -2268,6 +2373,7 @@ registerTool(
       }
       return ok({
         updated: verified,
+        approval,
         duplicate_import_ids: data.duplicate_import_ids,
         verification,
       });
@@ -2276,7 +2382,7 @@ registerTool(
 
 registerTool(
   "approve_transactions",
-  { description: "Approve unapproved transactions in bulk by filter, without hand-listing IDs. Fetches the current unapproved queue, optionally narrows by payeeId / categoryId / accountId, and sets approved:true on the matches. By default SKIPS uncategorized transactions (no category and not a transfer) so nothing is approved without a category; set includeUncategorized:true to override. Returns a compact summary (approved_count + verification counts), never full objects, so it is safe on large batches. Requires confirmed:true after explicit user confirmation.", inputSchema: {
+  { description: "Approve unapproved transactions in bulk by filter, without hand-listing IDs. Fetches the current unapproved queue, optionally narrows by payeeId / categoryId / accountId, and sets approved:true on the matches. By default SKIPS uncategorized transactions (no category and not a transfer) so nothing is approved without a category; set includeUncategorized:true to override. Returns a compact summary (approval counts + verification counts), never full objects, so it is safe on large batches. Because this tool only ever touches rows that were unapproved when it fetched them, newly_approved_count equals approved_count here; report newly_approved_count for consistency with update_transactions, where the two can differ. Requires confirmed:true after explicit user confirmation.", inputSchema: {
     budgetId: z.string().optional().describe("Budget ID (uses default if not provided)"),
     confirmed: z.literal(true).describe("Required. Pass true only after the user explicitly confirms this approval action."),
     expectedMatchedCount: z.number().int().nonnegative().optional().describe("Optional safety check. If provided and the current match count differs, no transactions are approved."),
@@ -2307,17 +2413,18 @@ registerTool(
         throw new Error(`approve_transactions matched ${txns.length} transactions, but expectedMatchedCount was ${expectedMatchedCount}; no transactions were approved.`);
       }
       if (txns.length === 0) {
-        return ok({ approved_count: 0, matched: 0, message: "No matching unapproved transactions to approve." });
+        return ok({ approved_count: 0, newly_approved_count: 0, matched: 0, message: "No matching unapproved transactions to approve." });
       }
       const updates = txns.map((t) => ({ id: t.id, approved: true }));
       const mapped = updates.map((t) => ({ id: t.id, ...mapTransactionUpdate(t) }));
       const { data: updData } = await api.transactions.updateTransactions(bid, { transactions: mapped });
       // The pre-write fetch above is the before-state: every row was unapproved.
+      const beforeById = new Map(txns.map((t) => [normalizeTransactionId(t.id), formatTransaction(t)]));
       await journalTransactionUpdates(
         "approve_transactions",
         bid,
         updates,
-        new Map(txns.map((t) => [normalizeTransactionId(t.id), formatTransaction(t)])),
+        beforeById,
         `Approved ${updates.length} transactions by filter`
       );
       const { verification, verified } = await verifyBulkTransactionUpdates(bid, updates, updData.transactions);
@@ -2329,7 +2436,7 @@ registerTool(
       }
       return ok({
         matched: txns.length,
-        approved_count: verified.filter((t) => t.approved).length,
+        ...summarizeApprovalChanges(updates, beforeById, verified),
         filters: { payeeId: payeeId || null, categoryId: categoryId || null, accountId: accountId || null, includeUncategorized: !!includeUncategorized },
         duplicate_import_ids: updData.duplicate_import_ids,
         verification: { checked: verification.checked, retried: verification.retried.length, failed: verification.failed.length },
@@ -2565,62 +2672,180 @@ registerTool(
 
 // ==================== Convenience Tools ====================
 
+// Category search over both the category name and its group name, tokenized so
+// a natural-language phrase still lands. A whole-phrase substring hit ranks
+// above per-token hits, and a name hit above a group hit, so the exact match a
+// single-word query would have found stays at the top of a multi-word result.
+function matchCategoriesByQuery(categoryGroups, query, { includeHidden = false } = {}) {
+  const phrase = normalizeSearchText(query);
+  const tokens = [...new Set(phrase.split(" ").filter(Boolean))];
+  if (tokens.length === 0) return [];
+  const scored = [];
+  for (const g of categoryGroups || []) {
+    if (g.hidden && !includeHidden) continue;
+    if (g.deleted) continue;
+    const groupText = normalizeSearchText(g.name);
+    for (const c of g.categories || []) {
+      if (c.hidden && !includeHidden) continue;
+      if (c.deleted) continue;
+      const nameText = normalizeSearchText(c.name);
+      const phraseInName = tokens.length > 1 && nameText.includes(phrase);
+      const phraseInGroup = tokens.length > 1 && groupText.includes(phrase);
+      const nameTokens = tokens.filter((t) => nameText.includes(t));
+      const groupTokens = tokens.filter((t) => groupText.includes(t));
+      const score = (phraseInName ? 100 : 0) + (phraseInGroup ? 40 : 0)
+        + nameTokens.length * 10 + groupTokens.length * 3;
+      if (score === 0) continue;
+      const matchedOn = [];
+      if (nameTokens.length > 0 || phraseInName) matchedOn.push("name");
+      if (groupTokens.length > 0 || phraseInGroup) matchedOn.push("group");
+      scored.push({
+        score,
+        category: c,
+        group: g,
+        matched_on: matchedOn,
+        matched_terms: [...new Set([...nameTokens, ...groupTokens])],
+      });
+    }
+  }
+  scored.sort((a, b) => b.score - a.score
+    || normalizeSearchText(a.category.name).localeCompare(normalizeSearchText(b.category.name)));
+  return scored;
+}
+
 registerTool(
   "search_categories",
-  { description: "Search categories by partial name match (case-insensitive). Useful for finding category IDs when you only know part of the name.", inputSchema: {
+  { description: "Search categories by name (case-insensitive, partial match), searching BOTH the category name and its category-group name. Multi-word queries are tokenized and OR-matched, so 'gym fitness membership' matches a category whose name contains any of those words — results are ranked, with whole-phrase and name matches above single-token and group-only matches. Each result reports matched_on ('name' and/or 'group') and matched_terms so a group-only hit is not mistaken for a name hit. Matching ignores HTML entity escaping and collapses runs of whitespace, so 'B&H' and 'B&amp;H' behave the same. Nothing here does synonym expansion: a category named 'GMCF Membership' will not surface for 'gym'. When a search comes back empty or looks wrong, fall back to list_categories (a full dump) before concluding the category does not exist.", inputSchema: {
     budgetId: z.string().optional().describe("Budget ID (uses default if not provided)"),
-    query: z.string().describe("Partial category name to search for (e.g. 'work' matches '💻 Work Expenses (Oliver LLC)')"),
+    query: z.string().describe("Category or group name to search for. Multi-word queries are OR-matched per word (e.g. 'work expenses' matches '💻 Work Expenses (Oliver LLC)' and anything in a 'Business Expenses' group)."),
+    includeHidden: z.boolean().optional().describe("If true, also search hidden categories and hidden category groups (default false)."),
   } },
-  ({ budgetId, query }) =>
+  ({ budgetId, query, includeHidden }) =>
     run(async () => {
       const { data } = await api.categories.getCategories(resolveBudgetId(budgetId));
-      const q = query.toLowerCase();
-      const matches = [];
-      for (const g of data.category_groups) {
-        if (g.hidden) continue;
-        for (const c of g.categories) {
-          if (c.hidden) continue;
-          if (c.name.toLowerCase().includes(q)) {
-            matches.push(withCurrencyFields({
-              id: c.id,
-              name: c.name,
-              group: g.name,
-              budgeted: dollars(c.budgeted),
-              activity: dollars(c.activity),
-              balance: dollars(c.balance),
-            }, c, ["budgeted", "activity", "balance"]));
-          }
-        }
+      const scored = matchCategoriesByQuery(data.category_groups, query, { includeHidden });
+      const matches = scored.map(({ category: c, group: g, matched_on, matched_terms }) =>
+        withCurrencyFields({
+          id: c.id,
+          name: c.name,
+          group: g.name,
+          matched_on,
+          matched_terms,
+          budgeted: dollars(c.budgeted),
+          activity: dollars(c.activity),
+          balance: dollars(c.balance),
+        }, c, ["budgeted", "activity", "balance"]));
+      if (matches.length === 0) {
+        return ok({
+          message: `No categories matching "${query}"`,
+          searched: "category names and category group names (hidden items excluded unless includeHidden:true)",
+          suggestions: "Try a single distinctive word, or call list_categories for the full list — this search does no synonym matching, so a category can exist under a name that shares no words with your query.",
+        });
       }
-      if (matches.length === 0) return ok({ message: `No categories matching "${query}"`, suggestions: "Try a shorter search term" });
       return ok(matches);
     })
 );
 
 registerTool(
   "search_payees",
-  { description: "Search payees by partial name match (case-insensitive). Useful for finding payee IDs.", inputSchema: {
+  { description: "Search payees by partial name match (case-insensitive). Matching ignores HTML entity escaping, so 'B&H' finds a payee YNAB stores as 'B&amp;H Photo Video'. Useful for finding payee IDs. Unlike search_categories this is a single substring match, not a tokenized OR — search one distinctive word at a time.", inputSchema: {
     budgetId: z.string().optional().describe("Budget ID (uses default if not provided)"),
     query: z.string().describe("Partial payee name to search for"),
   } },
   ({ budgetId, query }) =>
     run(async () => {
       const { data } = await api.payees.getPayees(resolveBudgetId(budgetId));
-      const q = query.toLowerCase();
+      // Match against the entity-decoded name so "B&H" finds a payee YNAB
+      // stores as "B&amp;H Photo Video" (and vice versa).
+      const q = normalizeSearchText(query);
       const matches = data.payees
-        .filter((p) => p.name.toLowerCase().includes(q))
+        .filter((p) => normalizeSearchText(p.name).includes(q))
         .map((p) => ({ id: p.id, name: p.name, transfer_account_id: p.transfer_account_id, deleted: p.deleted }));
       if (matches.length === 0) return ok({ message: `No payees matching "${query}"` });
       return ok(matches);
     })
 );
 
+// Compact projection: only the fields needed to act on a transaction.
+// matched_transaction_id survives for match_broken rows specifically — the
+// triage this tool documents for that flag is "GET the matched id", which
+// compact mode made impossible by dropping the id along with the other
+// import/match fields.
+function slimUnapprovedTransaction(t) {
+  const slim = {
+    id: t.id,
+    date: t.date,
+    payee_name: t.payee_name,
+    amount: t.amount,
+    category_name: t.category_name,
+    account_name: t.account_name,
+    flags: t.flags,
+  };
+  if (t.flags?.includes("match_broken")) {
+    slim.matched_transaction_id = t.matched_transaction_id ?? null;
+  }
+  return slim;
+}
+
+// Net total plus, when the rows run both directions, the inflow/outflow split.
+// A bare net ("Adobe: -12.83") reads as one small charge even when it is five
+// rows including two refunds, so the split is what keeps a header honest.
+function summarizeGroupAmounts(transactions) {
+  let inflow = 0, outflow = 0;
+  for (const t of transactions) {
+    if (t.amount > 0) inflow += t.amount;
+    else if (t.amount < 0) outflow += t.amount;
+  }
+  const mixed = inflow > 0 && outflow < 0;
+  return {
+    total: round2(inflow + outflow),
+    mixed_amount_signs: mixed,
+    ...(mixed ? { inflow_total: round2(inflow), outflow_total: round2(outflow) } : {}),
+  };
+}
+
+// Group headers describe the whole group, never just its first row. When a
+// payee's rows span categories, category_name is null (there is no single true
+// answer) and category_names lists every one of them, so a model summarizing
+// from headers alone cannot attribute the group to the wrong category.
+function buildUnapprovedPayeeGroups(categorized, { summary = false, compact = false } = {}) {
+  const byPayee = new Map();
+  for (const t of categorized) {
+    const key = t.payee_name || "Unknown Payee";
+    if (!byPayee.has(key)) byPayee.set(key, []);
+    byPayee.get(key).push(t);
+  }
+  return [...byPayee].map(([payee, transactions]) => {
+    const names = [];
+    let hasCategorylessRow = false;
+    for (const t of transactions) {
+      if (t.category_name == null) hasCategorylessRow = true;
+      else if (!names.includes(t.category_name)) names.push(t.category_name);
+    }
+    // A transfer or split row carries no category name of its own; paired with
+    // any named category that still makes the group mixed.
+    const mixedCategories = names.length > 1 || (names.length > 0 && hasCategorylessRow);
+    const base = {
+      payee,
+      category_name: mixedCategories ? null : (names[0] ?? null),
+      category_names: names,
+      mixed_categories: mixedCategories,
+      count: transactions.length,
+      ...summarizeGroupAmounts(transactions),
+      // Aggregate flags across all transactions in the group (deduplicated)
+      flags: [...new Set(transactions.flatMap((t) => t.flags ?? []))],
+    };
+    if (summary) return base;
+    return { ...base, transactions: compact ? transactions.map(slimUnapprovedTransaction) : transactions };
+  });
+}
+
 registerTool(
   "review_unapproved",
-  { description: "Get all unapproved transactions grouped by status: those already categorized (ready to approve) and those still uncategorized (need category first). Each transaction includes a 'flags' array: manually_entered (not bank-imported), match_broken (matched reference is stale — the `matched_transaction_id` field is read-only via this API; YNAB web/iOS UI is required to clear that link. The transaction itself remains fully mutable: you CAN approve, recategorize, and edit memo via update_transaction. The broken match persists as a cosmetic flag until the user resolves it in the UI.), scheduled_transaction_realized, new_payee (no transaction history for this payee), no_prior_amount_match (novel amount for this payee), category_drift:was_X (payee categorized differently before). Never approve uncategorized transactions without explicit user instruction. For large budgets the full response can exceed 100KB; pass summary:true for counts + by-payee aggregates only, or compact:true to keep per-transaction rows (with IDs) while dropping bulky fields so the response fits inline.", inputSchema: {
+  { description: "Get all unapproved transactions grouped by status: those already categorized (ready to approve) and those still uncategorized (need category first). Each transaction includes a 'flags' array: manually_entered (not bank-imported), match_broken (matched reference is stale — the `matched_transaction_id` field is read-only via this API; YNAB web/iOS UI is required to clear that link. The transaction itself remains fully mutable: you CAN approve, recategorize, and edit memo via update_transaction. The broken match persists as a cosmetic flag until the user resolves it in the UI.), scheduled_transaction_realized (a realized scheduled entry; its id is composite, uuid_YYYY-MM-DD, and is fully writable — see update_transaction), new_payee (no transaction history for this payee), no_prior_amount_match (novel amount for this payee), category_drift:was_X (payee categorized differently before). GROUP HEADERS: each by_payee group reports category_names (every distinct category in the group) and mixed_categories; category_name is only set when the whole group shares one category and is null when mixed_categories is true — never describe a mixed group by a single category. 'total' is the NET of the group; when its rows run both directions the group also carries mixed_amount_signs:true with inflow_total and outflow_total, so a net that hides refunds is visible as such. Never approve uncategorized transactions without explicit user instruction. For large budgets the full response can exceed 100KB; pass summary:true for counts + by-payee aggregates only, or compact:true to keep per-transaction rows (with IDs) while dropping bulky fields so the response fits inline.", inputSchema: {
     budgetId: z.string().optional().describe("Budget ID (uses default if not provided)"),
     summary: z.boolean().optional().describe("If true, omit per-transaction details from the response and return only counts + by-payee aggregates (for both ready_to_approve and needs_category_first). Use this when the full unapproved queue is large; drill into specifics with get_transactions afterwards."),
-    compact: z.boolean().optional().describe("If true (and summary is not set), keep per-transaction detail but return only the fields needed to act — id, date, payee_name, amount, category_name, account_name, flags — dropping bulky fields (import strings, subtransactions, matched/import ids) that push the full response past the inline size limit. Use when you need transaction IDs to approve or recategorize but the full queue would overflow."),
+    compact: z.boolean().optional().describe("If true (and summary is not set), keep per-transaction detail but return only the fields needed to act — id, date, payee_name, amount, category_name, account_name, flags — dropping bulky fields (import strings, subtransactions, import ids) that push the full response past the inline size limit. Rows flagged match_broken additionally keep matched_transaction_id, since triaging that flag means GETting the matched id. Use when you need transaction IDs to approve or recategorize but the full queue would overflow."),
   } },
   ({ budgetId, summary, compact }) =>
     run(async () => {
@@ -2686,54 +2911,21 @@ registerTool(
       const categorized = [], uncategorized = [];
       for (const t of flaggedTxns) (isCategorized(t) ? categorized : uncategorized).push(t);
 
-      // Compact projection: only the fields needed to act on a transaction
-      const slimTx = (t) => ({
-        id: t.id,
-        date: t.date,
-        payee_name: t.payee_name,
-        amount: t.amount,
-        category_name: t.category_name,
-        account_name: t.account_name,
-        flags: t.flags,
-      });
-
       // Group categorized transactions by payee for easier per-group review
-      const byPayee = {};
-      for (const t of categorized) {
-        const key = t.payee_name || "Unknown Payee";
-        if (!byPayee[key]) byPayee[key] = { payee: key, category_name: t.category_name, transactions: [] };
-        byPayee[key].transactions.push(t);
-      }
-      const groups = Object.values(byPayee).map((g) => {
-        // Aggregate flags across all transactions in the group (deduplicated)
-        const allFlags = [...new Set(g.transactions.flatMap((t) => t.flags))];
-        const base = {
-          payee: g.payee,
-          category_name: g.category_name,
-          count: g.transactions.length,
-          total: round2(g.transactions.reduce((sum, t) => sum + t.amount, 0)),
-          flags: allFlags,
-        };
-        return summary ? base : { ...base, transactions: compact ? g.transactions.map(slimTx) : g.transactions };
-      });
+      const groups = buildUnapprovedPayeeGroups(categorized, { summary, compact });
 
       // Build uncategorized payload — full transactions by default, by-payee aggregates when summary:true
       const uncategorizedPayload = (() => {
-        if (!summary) return compact ? uncategorized.map(slimTx) : uncategorized;
-        const byPayeeUncat = {};
-        for (const t of uncategorized) {
-          const key = t.payee_name || "Unknown Payee";
-          if (!byPayeeUncat[key]) byPayeeUncat[key] = { payee_name: key, count: 0, total: 0, flags: new Set() };
-          byPayeeUncat[key].count += 1;
-          byPayeeUncat[key].total += t.amount;
-          for (const f of t.flags) byPayeeUncat[key].flags.add(f);
-        }
-        return Object.values(byPayeeUncat).map((g) => ({
-          payee_name: g.payee_name,
-          count: g.count,
-          total: round2(g.total),
-          flags: [...g.flags],
-        }));
+        if (!summary) return compact ? uncategorized.map(slimUnapprovedTransaction) : uncategorized;
+        return buildUnapprovedPayeeGroups(uncategorized, { summary: true })
+          .map(({ payee, count, total, mixed_amount_signs, inflow_total, outflow_total, flags }) => ({
+            payee_name: payee,
+            count,
+            total,
+            mixed_amount_signs,
+            ...(mixed_amount_signs ? { inflow_total, outflow_total } : {}),
+            flags,
+          }));
       })();
 
       const needsCategoryFirst = {
@@ -3643,6 +3835,7 @@ const YNAB_WRITE_SAFETY_TEXT = `# Write Safety Rules for this server
 - Never batch-approve on vague instructions ("approve the rest"). List the exact transactions (payee, amount, category), get explicit confirmation, and state what you are NOT approving.
 - Never fabricate transaction IDs. Extract them from review_unapproved / get_transactions results. A batch failing with "transaction does not exist in this budget" is the signature of fabricated IDs.
 - After combined category+approval writes, check the returned verification block; require verification.failed to be empty. Do not use the approval-queue count as the only success check — approval can succeed while the category write did not persist.
+- Report newly_approved_count, not approved_count, when telling a user what you approved. approved_count includes rows that were already approved before the call; the two differ whenever a batch mixes approved and unapproved rows.
 - Recategorizing a transaction does not move budgeted dollars. To true-up the month, also call update_month_category (it sets an absolute value: compute old budgeted − amount and new budgeted + amount).
 - Transfers: use the destination account's transfer_payee_id as payeeId; do not invent a "Transfer : ..." payee name.
 - Every transaction write is journaled locally; list_undo_history shows the journal and undo_operation reverses a journaled write.`;
@@ -3661,13 +3854,16 @@ const YNAB_FLAGS_REFERENCE_TEXT = `# review_unapproved flags reference
 | Flag | Meaning | Suggested action |
 |------|---------|------------------|
 | manually_entered | Hand-keyed, not bank-imported | Confirm it's intentional |
-| match_broken | Stale matched_transaction_id reference | The transaction itself is fully editable; only the stale link is immutable via API. GET the matched id: not-found = orphan (safe), live = duplicate (keep one). UI cleanup of the link is cosmetic. |
+| match_broken | Stale matched_transaction_id reference | The transaction itself is fully editable; only the stale link is immutable via API. GET the matched id — kept in the row even under compact:true — to triage: not-found = orphan (safe), live = duplicate (keep one). UI cleanup of the link is cosmetic. |
 | no_prior_amount_match | First time this amount appeared for this payee | Review before approving |
 | category_drift:was_X | Payee previously categorized elsewhere | Surface the drift with prior-category evidence; ask before fixing |
 | new_payee | No history for this payee | Confirm payee and category |
-| scheduled_transaction_realized | Came from a scheduled entry | Verify amount and category match expectations |
+| scheduled_transaction_realized | Came from a scheduled entry; its id is composite (uuid_YYYY-MM-DD) | Verify amount and category match expectations. The composite id is writable — pass it verbatim to update_transaction / update_transactions; do not strip the date suffix and do not treat the row as read-only. |
 
-Transactions flagged match_broken, or manually_entered + no_prior_amount_match, should get explicit user sign-off regardless of batch size.`;
+Transactions flagged match_broken, or manually_entered + no_prior_amount_match, should get explicit user sign-off regardless of batch size.
+
+## Reading group headers
+by_payee groups carry \`category_names\` (every distinct category in the group) and \`mixed_categories\`. \`category_name\` is null whenever \`mixed_categories\` is true — describe such a group by its list, never by one category. \`total\` is the group's NET; when \`mixed_amount_signs\` is true the group also carries \`inflow_total\` and \`outflow_total\`, and the net alone will read as a single small charge when it is really charges minus refunds.`;
 
 const YNAB_RESOURCES = [
   ["methodology", "YNAB methodology primer: the Four Rules, credit card handling, reconciliation, age of money, and amount conventions for this server.", YNAB_METHODOLOGY_TEXT],
@@ -3756,6 +3952,13 @@ return {
     parseToolExecuteInput,
     verifyBulkTransactionUpdates,
     beforeFieldsForUpdate,
+    summarizeApprovalChanges,
+    decodeHtmlEntities,
+    decodeTextFieldsDeep,
+    normalizeSearchText,
+    matchCategoriesByQuery,
+    slimUnapprovedTransaction,
+    buildUnapprovedPayeeGroups,
     summarizeIncomeExpenseByMonth,
     detectRecurringFromTransactions,
     csvEscape,
@@ -3814,6 +4017,13 @@ const {
   parseToolExecuteInput,
   verifyBulkTransactionUpdates,
   beforeFieldsForUpdate,
+  summarizeApprovalChanges,
+  decodeHtmlEntities,
+  decodeTextFieldsDeep,
+  normalizeSearchText,
+  matchCategoriesByQuery,
+  slimUnapprovedTransaction,
+  buildUnapprovedPayeeGroups,
   summarizeIncomeExpenseByMonth,
   detectRecurringFromTransactions,
   csvEscape,
@@ -3842,6 +4052,13 @@ export {
   parseToolExecuteInput,
   verifyBulkTransactionUpdates,
   beforeFieldsForUpdate,
+  summarizeApprovalChanges,
+  decodeHtmlEntities,
+  decodeTextFieldsDeep,
+  normalizeSearchText,
+  matchCategoriesByQuery,
+  slimUnapprovedTransaction,
+  buildUnapprovedPayeeGroups,
   summarizeIncomeExpenseByMonth,
   detectRecurringFromTransactions,
   csvEscape,

--- a/package-lock.json
+++ b/package-lock.json
@@ -454,9 +454,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
+      "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==",
       "funding": [
         {
           "type": "github",
@@ -600,9 +600,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.30",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
-      "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -651,9 +651,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,9 @@
   "overrides": {
     "@hono/node-server": "2.0.11",
     "body-parser": "2.3.0",
-    "fast-uri": "3.1.4"
+    "fast-uri": "4.1.2",
+    "hono": "4.13.0",
+    "ip-address": "10.4.0"
   },
   "engines": {
     "node": ">=18"

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -28,6 +28,13 @@ const {
   parseToolExecuteInput,
   verifyBulkTransactionUpdates,
   beforeFieldsForUpdate,
+  summarizeApprovalChanges,
+  decodeHtmlEntities,
+  decodeTextFieldsDeep,
+  normalizeSearchText,
+  matchCategoriesByQuery,
+  slimUnapprovedTransaction,
+  buildUnapprovedPayeeGroups,
   summarizeIncomeExpenseByMonth,
   detectRecurringFromTransactions,
   csvEscape,
@@ -372,4 +379,224 @@ test("buildTransactionsCsv emits header plus one row per transaction", () => {
 
 test("currentBudgetMonth is the first of the current month", () => {
   assert.match(currentBudgetMonth(), /^\d{4}-\d{2}-01$/);
+});
+
+// --- v5.2 connector-finding fixes ---
+
+test("buildUnapprovedPayeeGroups reports every category a group spans", () => {
+  const txns = [
+    { id: "t1", payee_name: "Venmo", amount: -20, category_name: "🏖️ Cuttyhunk", flags: [] },
+    { id: "t2", payee_name: "Venmo", amount: -30, category_name: "🚲 eBike", flags: [] },
+    { id: "t3", payee_name: "Venmo", amount: -40, category_name: "🚲 eBike", flags: [] },
+    { id: "t4", payee_name: "Venmo", amount: -10, category_name: "🚲 eBike", flags: [] },
+  ];
+  const [group] = buildUnapprovedPayeeGroups(txns, { summary: true });
+  // The first row's category must not stand in for the whole group.
+  assert.equal(group.category_name, null);
+  assert.equal(group.mixed_categories, true);
+  assert.deepEqual(group.category_names, ["🏖️ Cuttyhunk", "🚲 eBike"]);
+  assert.equal(group.count, 4);
+  assert.equal(group.total, -100);
+});
+
+test("buildUnapprovedPayeeGroups keeps a single-category header simple", () => {
+  const txns = [
+    { id: "t1", payee_name: "Cafe", amount: -5, category_name: "Dining", flags: ["new_payee"] },
+    { id: "t2", payee_name: "Cafe", amount: -7, category_name: "Dining", flags: [] },
+  ];
+  const [group] = buildUnapprovedPayeeGroups(txns, { summary: true });
+  assert.equal(group.category_name, "Dining");
+  assert.equal(group.mixed_categories, false);
+  assert.deepEqual(group.category_names, ["Dining"]);
+  assert.equal(group.mixed_amount_signs, false);
+  assert.equal("inflow_total" in group, false);
+  assert.deepEqual(group.flags, ["new_payee"]);
+});
+
+test("buildUnapprovedPayeeGroups splits inflow and outflow when a net hides reversals", () => {
+  const txns = [
+    { id: "t1", payee_name: "Adobe", amount: -22.83, category_name: "Software", flags: [] },
+    { id: "t2", payee_name: "Adobe", amount: -10, category_name: "Software", flags: [] },
+    { id: "t3", payee_name: "Adobe", amount: 10, category_name: "Software", flags: [] },
+    { id: "t4", payee_name: "Adobe", amount: 9.99, category_name: "Software", flags: [] },
+    { id: "t5", payee_name: "Adobe", amount: 0.01, category_name: "Software", flags: [] },
+  ];
+  const [group] = buildUnapprovedPayeeGroups(txns, { summary: true });
+  assert.equal(group.total, -12.83);
+  assert.equal(group.mixed_amount_signs, true);
+  assert.equal(group.inflow_total, 20);
+  assert.equal(group.outflow_total, -32.83);
+});
+
+test("buildUnapprovedPayeeGroups treats a categoryless row as mixed", () => {
+  const txns = [
+    { id: "t1", payee_name: "Chase", amount: -100, category_name: null, flags: [] },
+    { id: "t2", payee_name: "Chase", amount: -20, category_name: "Fees", flags: [] },
+  ];
+  const [group] = buildUnapprovedPayeeGroups(txns, { summary: true });
+  assert.equal(group.mixed_categories, true);
+  assert.equal(group.category_name, null);
+  assert.deepEqual(group.category_names, ["Fees"]);
+});
+
+test("compact rows keep matched_transaction_id only for match_broken", () => {
+  const broken = slimUnapprovedTransaction({
+    id: "t1", date: "2026-07-01", payee_name: "Venmo", amount: -20,
+    category_name: "Dining", account_name: "Checking", memo: "bulky",
+    matched_transaction_id: "m1", import_id: null, flags: ["match_broken"],
+  });
+  assert.equal(broken.matched_transaction_id, "m1");
+  assert.equal("memo" in broken, false);
+
+  const clean = slimUnapprovedTransaction({
+    id: "t2", date: "2026-07-01", payee_name: "Cafe", amount: -5,
+    category_name: "Dining", account_name: "Checking",
+    matched_transaction_id: "m2", flags: [],
+  });
+  assert.equal("matched_transaction_id" in clean, false);
+});
+
+test("summarizeApprovalChanges separates newly approved from already approved", () => {
+  const requested = [
+    { id: "t1", approved: true },
+    { id: "t2", categoryId: "c1" },
+    { id: "t3", categoryId: "c2" },
+    { id: "t4", approved: true },
+  ];
+  const before = new Map([
+    ["t1", { approved: false }],
+    ["t2", { approved: true }],
+    ["t3", { approved: true }],
+    // t4 has no before-state (importId row whose refetch failed)
+  ]);
+  const verified = [
+    { id: "t1", approved: true },
+    { id: "t2", approved: true },
+    { id: "t3", approved: true },
+    { id: "t4", approved: true },
+  ];
+  assert.deepEqual(summarizeApprovalChanges(requested, before, verified), {
+    approved_count: 4,
+    newly_approved_count: 1,
+    already_approved_count: 2,
+    approval_state_unknown_count: 1,
+  });
+});
+
+test("summarizeApprovalChanges ignores rows that did not end approved", () => {
+  const requested = [{ id: "t1", memo: "x" }];
+  const before = new Map([["t1", { approved: false }]]);
+  assert.deepEqual(summarizeApprovalChanges(requested, before, [{ id: "t1", approved: false }]), {
+    approved_count: 0,
+    newly_approved_count: 0,
+    already_approved_count: 0,
+    approval_state_unknown_count: 0,
+  });
+});
+
+test("summarizeApprovalChanges matches composite scheduled ids to their before-state", () => {
+  const requested = [{ id: "abc_2026-07-30", approved: true }];
+  const before = new Map([["abc", { approved: false }]]);
+  assert.equal(
+    summarizeApprovalChanges(requested, before, [{ id: "abc", approved: true }]).newly_approved_count,
+    1,
+  );
+});
+
+test("decodeHtmlEntities decodes named and numeric references only", () => {
+  assert.equal(decodeHtmlEntities("B&amp;H Photo Video"), "B&H Photo Video");
+  assert.equal(decodeHtmlEntities("Ben &amp; Jerry&#39;s"), "Ben & Jerry's");
+  assert.equal(decodeHtmlEntities("Caf&eacute; &#x2014; Montpelier"), "Café — Montpelier");
+  // Bare ampersands and unknown entities are left exactly as they are.
+  assert.equal(decodeHtmlEntities("AT&T"), "AT&T");
+  assert.equal(decodeHtmlEntities("Tom &notanentity; Co"), "Tom &notanentity; Co");
+  // Lone surrogates would break JSON serialization; leave them encoded.
+  assert.equal(decodeHtmlEntities("&#xD800;"), "&#xD800;");
+  assert.equal(decodeHtmlEntities(null), null);
+  assert.equal(decodeHtmlEntities(42), 42);
+});
+
+test("decodeTextFieldsDeep rewrites only allow-listed text fields", () => {
+  const payload = {
+    id: "b&amp;h",
+    csv: "payee\nB&amp;H",
+    ready_to_approve: {
+      by_payee: [{
+        payee: "B&amp;H Photo Video",
+        category_name: "Photo &amp; Video",
+        transactions: [{ id: "t1", payee_name: "B&amp;H Photo Video", memo: "lens &amp; cap" }],
+      }],
+    },
+  };
+  decodeTextFieldsDeep(payload);
+  assert.equal(payload.id, "b&amp;h", "ids are never rewritten");
+  assert.equal(payload.csv, "payee\nB&amp;H", "raw payloads are never rewritten");
+  assert.equal(payload.ready_to_approve.by_payee[0].payee, "B&H Photo Video");
+  assert.equal(payload.ready_to_approve.by_payee[0].category_name, "Photo & Video");
+  assert.equal(payload.ready_to_approve.by_payee[0].transactions[0].payee_name, "B&H Photo Video");
+  assert.equal(payload.ready_to_approve.by_payee[0].transactions[0].memo, "lens & cap");
+});
+
+test("decodeTextFieldsDeep survives a cyclic payload", () => {
+  const node = { name: "A &amp; B" };
+  node.self = node;
+  decodeTextFieldsDeep(node);
+  assert.equal(node.name, "A & B");
+});
+
+test("normalizeSearchText folds case, entities, and whitespace", () => {
+  assert.equal(normalizeSearchText("  B&amp;H   Photo  "), "b&h photo");
+  assert.equal(normalizeSearchText(null), "");
+});
+
+const CATEGORY_GROUPS = [
+  { name: "Health & Medical", hidden: false, deleted: false, categories: [
+    { id: "c1", name: "🏊‍♂️ GMCF Membership", hidden: false, deleted: false },
+    { id: "c2", name: "💊 Pharmacy", hidden: false, deleted: false },
+  ] },
+  { name: "Recreation", hidden: false, deleted: false, categories: [
+    { id: "c3", name: "🚲 eBike", hidden: false, deleted: false },
+    { id: "c4", name: "Gym Towels", hidden: false, deleted: false },
+  ] },
+  { name: "Archive", hidden: true, deleted: false, categories: [
+    { id: "c5", name: "Old Gym", hidden: false, deleted: false },
+  ] },
+];
+
+test("matchCategoriesByQuery ORs multi-word queries instead of failing them", () => {
+  // "gym fitness membership" previously matched nothing; each word is tried.
+  const ids = matchCategoriesByQuery(CATEGORY_GROUPS, "gym fitness membership").map((m) => m.category.id);
+  assert.deepEqual(ids.slice().sort(), ["c1", "c4"]);
+  const gmcf = matchCategoriesByQuery(CATEGORY_GROUPS, "gym fitness membership")
+    .find((m) => m.category.id === "c1");
+  assert.deepEqual(gmcf.matched_terms, ["membership"]);
+  assert.deepEqual(gmcf.matched_on, ["name"]);
+});
+
+test("matchCategoriesByQuery searches group names as well as category names", () => {
+  const matches = matchCategoriesByQuery(CATEGORY_GROUPS, "health");
+  assert.deepEqual(matches.map((m) => m.category.id), ["c1", "c2"]);
+  assert.deepEqual(matches[0].matched_on, ["group"]);
+});
+
+test("matchCategoriesByQuery ranks whole-phrase and name hits first", () => {
+  const matches = matchCategoriesByQuery(CATEGORY_GROUPS, "gym towels");
+  assert.equal(matches[0].category.id, "c4");
+  assert.deepEqual(matches[0].matched_on, ["name"]);
+});
+
+test("matchCategoriesByQuery hides hidden groups unless asked", () => {
+  assert.deepEqual(matchCategoriesByQuery(CATEGORY_GROUPS, "old").map((m) => m.category.id), []);
+  assert.deepEqual(
+    matchCategoriesByQuery(CATEGORY_GROUPS, "old", { includeHidden: true }).map((m) => m.category.id),
+    ["c5"],
+  );
+});
+
+test("matchCategoriesByQuery matches across entity escaping and empty queries", () => {
+  const groups = [{ name: "Shopping", hidden: false, deleted: false, categories: [
+    { id: "c9", name: "B&amp;H Photo", hidden: false, deleted: false },
+  ] }];
+  assert.deepEqual(matchCategoriesByQuery(groups, "b&h").map((m) => m.category.id), ["c9"]);
+  assert.deepEqual(matchCategoriesByQuery(groups, "   "), []);
 });

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@cloudflare/workers-oauth-provider": "~0.8.1",
         "agents": "~0.17.4",
-        "hono": "^4.12.27"
+        "hono": "^4.13.0"
       },
       "devDependencies": {
         "wrangler": "4.113.0"
@@ -1125,9 +1125,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1145,9 +1142,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1165,9 +1159,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1185,9 +1176,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1205,9 +1193,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1225,9 +1210,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1245,9 +1227,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1265,9 +1244,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1285,9 +1261,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1311,9 +1284,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1337,9 +1307,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1363,9 +1330,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1389,9 +1353,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1415,9 +1376,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1441,9 +1399,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1467,9 +1422,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1807,9 +1759,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1826,9 +1775,6 @@
       "integrity": "sha512-wUqdwJBbAv0APN87GecstdMUtLjjNTs0hBALpxETD73mccFxdmt/XeizXDtN5RAlBwNKmI+Tg+blect2G+8IeQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1847,9 +1793,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1866,9 +1809,6 @@
       "integrity": "sha512-RzuHrBh8X8Hntd2N4VR02QGEciq/9JhcZoTpR/Cee6otRrlILGCf3cg2ygHuih+ZebUnWmMrDX6ITI85btO6rQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1887,9 +1827,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1906,9 +1843,6 @@
       "integrity": "sha512-gyrxLQ9NfGb/9LoVnC4kb9miUghw1mghnkfYvNHSnVIXriabnfgGPUP4RLcJm87q3KgYz4FYUG8IDiWUT+CpSw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2790,9 +2724,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
+      "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==",
       "funding": [
         {
           "type": "github",
@@ -2973,9 +2907,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.30",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
-      "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -3035,9 +2969,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/worker/package.json
+++ b/worker/package.json
@@ -13,14 +13,15 @@
   "dependencies": {
     "@cloudflare/workers-oauth-provider": "~0.8.1",
     "agents": "~0.17.4",
-    "hono": "^4.12.27"
+    "hono": "^4.13.0"
   },
   "devDependencies": {
     "wrangler": "4.113.0"
   },
   "overrides": {
     "@hono/node-server": "2.0.11",
-    "fast-uri": "3.1.4",
+    "fast-uri": "4.1.2",
+    "ip-address": "10.4.0",
     "sharp": "0.35.3"
   }
 }


### PR DESCRIPTION
Fixes the seven defects from the live connector triage session. The eighth item (`audit_account_reconciliation`) reported no problem and is unchanged.

Every defect here has the same shape: a response a model can read correctly and still describe to a user wrongly.

## 1. `review_unapproved` group headers described one row, not the group

Headers were built from the first transaction in the group, so a Venmo group reported `category_name: "🏖️ Cuttyhunk"` while three of its four rows were 🚲 eBike.

Groups now carry `category_names` (every distinct category) and `mixed_categories`. `category_name` is `null` whenever the group is mixed — there is no single-category field left to quote for a group that has no single category.

The same failure applied to `total`. The Adobe group's `-12.83` looked like one small charge; it was five rows including two positive reversals. A group whose rows run both directions now reports `mixed_amount_signs: true` with `inflow_total` and `outflow_total` beside the net. The uncategorized summary aggregates get the same treatment.

## 2. `approved_count` answered a different question than the one asked

It counted rows that *end* approved, so nine entries with one `approved: true` returned `approved_count: 3` because two rows arrived already approved.

`update_transactions` now returns `newly_approved_count`, `already_approved_count` and `approval_state_unknown_count` alongside it, computed against the before-state fetch the undo journal already performs — no extra API requests. `approve_transactions` reports the same field names; there the two counts are necessarily equal, since it only touches rows that were unapproved when it fetched them. The tool descriptions and the `ynab://guide/write-safety` resource now say to report `newly_approved_count` to a user.

## 3. `compact: true` dropped the field its own triage requires

The description tells a model to GET `matched_transaction_id` to triage `match_broken`, and compact mode dropped it. Compact rows now keep it — only for rows carrying the flag, so the size saving survives everywhere else.

## 4 & 5. `search_categories` could not handle multi-word queries and searched names only

Queries are now tokenized and OR-matched over both the category name and its group name, ranked (whole-phrase above token, name above group), with `matched_on` / `matched_terms` per result so a group-only hit is not mistaken for a name hit. Added `includeHidden`, and deleted categories are now excluded from results.

One correction on the finding as written: searching group names does **not** make `gym` find `🏊‍♂️ GMCF Membership` in the "Health & Medical" group — those share no word, and this does no synonym expansion. What finds it is the tokenized query (`gym fitness membership` → `membership`). The empty-result message now states that limit and points at `list_categories` instead of the useless "Try a shorter search term".

## 6. HTML entities were not decoded

Decoding happens once, in `ok()`, over an allow-list of name/memo/note fields — so no per-tool formatter can forget it, and no id, date, or raw CSV payload is touched. Name search normalizes both sides, so `B&H` and `B&amp;H` behave identically in `search_categories` and `search_payees`. Writes still send exactly what the caller supplied.

## 7. Composite scheduled IDs are writable

`d9e7c3c2-…_2026-07-30` accepts writes and returns a full object; the suffix invites the opposite assumption. Now documented in `update_transaction` (description and `transactionId`), in the `scheduled_transaction_realized` row of the flags reference resource, and in a README section.

## Verification

- 45 offline unit tests pass (17 new, covering group headers, approval counts, compact match rows, entity decoding, and category matching)
- 25 Worker tests pass; safety-model check and release-consistency check pass
- `smoke:list-tools` passes
- Exercised end to end through an in-memory MCP client against stubbed YNAB payloads reproducing the Venmo, Adobe and B&amp;H rows from the findings: mixed group → `category_name: null` + `category_names`; Adobe → `inflow_total: 20` / `outflow_total: -32.83` on a `-12.83` net; the `match_broken` row keeps its `matched_transaction_id` under `compact: true`; `gym fitness membership` returns GMCF Membership; `health` returns the group's categories with `matched_on: ["group"]`

No live-API test was run — that needs a token and would write to a real budget.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U2bn85WRKbPyY8u8doMF8G)_