### PR TITLE
release: 5.2.0, and fix the MCPB bundle build

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "ynab-mcp-server",
-      "version": "5.1.1",
+      "version": "5.2.0",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "ynab-mcp-server",
-      "version": "5.1.1",
+      "version": "5.2.0",
       "description": "YNAB MCP connector for budgets, transactions, categories, scheduled transactions, accounts, months, payees, and budget review workflows.",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ynab-mcp-server",
-  "version": "5.1.1",
+  "version": "5.2.0",
   "description": "YNAB MCP connector for budgets, transactions, categories, scheduled transactions, accounts, months, payees, and budget review workflows.",
   "author": {
     "name": "Oliver Ames",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "ynab-mcp-server",
       "displayName": "YNAB",
       "description": "YNAB MCP connector for budgets, transactions, categories, scheduled transactions, accounts, months, payees, and budget review workflows.",
-      "version": "5.1.1",
+      "version": "5.2.0",
       "author": {
         "name": "Oliver Ames",
         "email": "oliverames@gmail.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ynab-mcp-server",
   "displayName": "YNAB",
-  "version": "5.1.1",
+  "version": "5.2.0",
   "description": "YNAB MCP connector for budgets, transactions, categories, scheduled transactions, accounts, months, payees, and budget review workflows.",
   "author": {
     "name": "Oliver Ames",

--- a/.hermes-plugin/marketplace.json
+++ b/.hermes-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "ynab-mcp-server",
-      "version": "5.1.1",
+      "version": "5.2.0",
       "description": "YNAB MCP connector for budgets, transactions, categories, scheduled transactions, accounts, months, payees, and budget review workflows.",
       "source": {
         "source": "local",

--- a/.hermes-plugin/plugin.json
+++ b/.hermes-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ynab-mcp-server",
-  "version": "5.1.1",
+  "version": "5.2.0",
   "description": "YNAB MCP connector for budgets, transactions, categories, scheduled transactions, accounts, months, payees, and budget review workflows.",
   "source": {
     "source": "local",

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -1,5 +1,35 @@
 # Worklog
 
+## 2026-08-05 - Release prep for 5.2.0, and the MCPB build was already broken
+
+**Version**: 5.1.1 → 5.2.0. Minor, not patch: the connector fixes add response
+fields (`category_names`, `mixed_categories`, `inflow_total` / `outflow_total`,
+`newly_approved_count` and its siblings, `matched_on` / `matched_terms`) and a
+new `includeHidden` parameter on `search_categories`. Nothing was removed, and
+`approved_count` keeps its old meaning, so no consumer breaks.
+
+**`build:mcpb` was failing before this branch**: `./publish.sh` stops at the
+bundle step with ``npm ci`` rejecting the copied lockfile — "Missing:
+@hono/node-server@1.19.17 from lock file". Cause: `scripts/build-mcpb.mjs`
+writes a staged `package.json` from a field allow-list that omits `overrides`,
+then copies `package-lock.json` verbatim. The lock was resolved *with* the
+overrides applied, so the staged manifest and the lock disagree. Verified
+pre-existing by staging the v5.1.1 tree (commit `7d04e6d`) the same way: it
+fails identically. The dependency bump in this release only lengthened the list
+of missing packages.
+
+Beyond unblocking the release, this mattered on its own: had the staged install
+succeeded without the overrides, the `.mcpb` users actually run would have
+shipped the unpinned, advisory-flagged `fast-uri` and `hono`. The staged
+manifest now carries `overrides`, and the built bundle was unzipped and
+checked — `fast-uri 4.1.2`, `hono 4.13.0`, `ip-address 10.4.0`.
+
+**Not published**: `npm publish` needs registry credentials this environment
+does not have (`ENEEDAUTH`, no `~/.npmrc`, no token in env). Everything up to
+that call is done and green: all offline suites, the Wrangler dry-run, release
+consistency at 5.2.0, `npm pack --dry-run` (16 files, 860.9 kB), and
+`npm publish --dry-run`. The remaining step is one authenticated command.
+
 ## 2026-08-05 - Fixed seven connector findings from a live triage session
 
 **Context**: A live session using the hosted connector produced eight findings.

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ynab-mcp-server",
-  "version": "5.1.1",
+  "version": "5.2.0",
   "description": "YNAB MCP connector for budgets, transactions, categories, scheduled transactions, accounts, months, payees, and budget review workflows.",
   "author": {
     "name": "Oliver Ames",

--- a/index.js
+++ b/index.js
@@ -452,7 +452,7 @@ const {
   writesEnabled: allowWrites = false,
   journal = null,
   runtime = {},
-  serverInfo = { name: "YNAB Local", version: "5.1.1" },
+  serverInfo = { name: "YNAB Local", version: "5.2.0" },
 } = options;
 
 // Most-recently-seen access token, kept only so sanitizeErrorMessage can

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oliverames/mcp-server-for-ynab",
-  "version": "5.1.1",
+  "version": "5.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oliverames/mcp-server-for-ynab",
-      "version": "5.1.1",
+      "version": "5.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oliverames/mcp-server-for-ynab",
-  "version": "5.1.1",
+  "version": "5.2.0",
   "description": "Local MCP server for YNAB budget operations",
   "license": "MIT",
   "repository": {

--- a/scripts/build-mcpb.mjs
+++ b/scripts/build-mcpb.mjs
@@ -33,6 +33,12 @@ function writeJson(relativePath, value) {
   fs.writeFileSync(destination, `${JSON.stringify(value, null, 2)}\n`);
 }
 
+// The staged package.json must carry `overrides` alongside `dependencies`:
+// package-lock.json is copied verbatim, and it was resolved WITH the overrides
+// applied. Dropping them made the staged `npm ci` reject the lock as out of
+// sync ("Missing: @hono/node-server@... from lock file"), and would otherwise
+// install the unpinned — currently advisory-flagged — transitive versions into
+// the bundle users actually run.
 const bundlePackage = {
   name: pkg.name,
   version: pkg.version,
@@ -40,6 +46,7 @@ const bundlePackage = {
   type: pkg.type,
   main: pkg.main,
   dependencies: pkg.dependencies,
+  ...(pkg.overrides ? { overrides: pkg.overrides } : {}),
   engines: pkg.engines,
 };
 

--- a/worker/src/brand-assets.js
+++ b/worker/src/brand-assets.js
@@ -74,7 +74,7 @@ export const CONNECTOR_FAVICON_256_PNG_URL =
 export const REMOTE_SERVER_INFO = {
   name: "YNAB",
   title: "YNAB",
-  version: "5.1.1",
+  version: "5.2.0",
   description:
     "Independent open-source connector for accessing a user's own YNAB budget. Not affiliated with, sponsored by, or endorsed by YNAB.",
   icons: [


### PR DESCRIPTION
Release prep for 5.2.0. **Not published** — this environment has no npm credentials (`npm publish` returns `ENEEDAUTH`; there is no `~/.npmrc` and no token in env). Everything up to that one authenticated command is done and verified.

## Version

5.1.1 → 5.2.0 across `package.json`, the lockfile, `index.js` serverInfo, the Worker's `REMOTE_SERVER_INFO`, and every plugin manifest (via `npm run sync:plugin`).

Minor rather than patch: the connector fixes in #10 add response fields (`category_names`, `mixed_categories`, `inflow_total`/`outflow_total`, `newly_approved_count` and siblings, `matched_on`/`matched_terms`) and a new `includeHidden` parameter on `search_categories`. Nothing was removed and `approved_count` keeps its old meaning, so no consumer breaks.

## `build:mcpb` was already failing on main

`./publish.sh` cannot complete on main — it stops at the bundle step with `npm ci` rejecting the copied lockfile:

```
npm error Missing: @hono/node-server@1.19.17 from lock file
```

`scripts/build-mcpb.mjs` writes the staged `package.json` from a field allow-list that omits `overrides`, then copies `package-lock.json` verbatim. The lock was resolved *with* the overrides applied, so the staged manifest and the lock disagree and `npm ci` refuses.

Confirmed pre-existing, not caused by the dependency bump: staging the v5.1.1 tree (`7d04e6d`) the same way fails identically, with the same `@hono/node-server` line. The bump only lengthened the list of missing packages.

This matters beyond unblocking the release. Had the staged install succeeded without the overrides, the `.mcpb` users actually run would have shipped the unpinned, advisory-flagged `fast-uri` and `hono`. The fix carries `overrides` into the staged manifest; the built bundle was unzipped and checked: `fast-uri 4.1.2`, `hono 4.13.0`, `ip-address 10.4.0`.

## Verification

Full `publish.sh` check sequence at 5.2.0:

- 45 unit tests, safety-model tests, `smoke:list-tools`, 25 Worker tests
- `wrangler deploy --dry-run` (Total Upload 4990.17 KiB / gzip 1492.84 KiB)
- `release:check` — every version assertion passes at 5.2.0
- `build:mcpb` → `dist/mcp-server-for-ynab-5.2.0.mcpb` (6,463,160 bytes), contents verified
- `npm pack --dry-run` — 16 files, 860.9 kB packed, 1.1 MB unpacked
- `npm publish --dry-run` — clean

## To finish the release

```bash
git checkout main && git pull
npm publish --access public      # the only step that needs credentials
npm run release:check:registry
git tag v5.2.0 && git push origin v5.2.0   # triggers the GitHub release workflow
```

Version files are already bumped in this branch, so re-running `./publish.sh` after merging would bump to 5.3.0 — publish directly instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U2bn85WRKbPyY8u8doMF8G)_