### PR TITLE
fix: advertise JSON Schema 2020-12 dialect in tools/list

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ import { homedir } from "node:os";
 import path from "node:path";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import * as ynab from "ynab";
 
@@ -443,6 +444,33 @@ function createFsJournal(filePath) {
 //     sources_checked, values, tokenLookupError, setupGuide } — auth-status
 //     reporting only; all fields optional.
 //   serverInfo: { name, version } override.
+
+// The installed MCP SDK (@modelcontextprotocol/sdk 1.29-1.30) converts every
+// tool's zod input/output schema to JSON Schema without passing a dialect
+// target, so `tools/list` always advertises
+// "$schema": "http://json-schema.org/draft-07/schema#" — even for zod v4,
+// where the SDK's own converter defaults to draft-7 whenever no target is
+// given. Our tool schemas are plain (type/properties/required/
+// additionalProperties), which is valid under 2020-12 as-is, but MCP clients
+// whose default validator only accepts the 2020-12 dialect reject every tool
+// call outright before any handler runs. Rewrite the advertised dialect
+// after the SDK builds its response instead of patching node_modules.
+const JSON_SCHEMA_2020_12 = "https://json-schema.org/draft/2020-12/schema";
+
+function fixListToolsSchemaDialect(server) {
+  const rawServer = server.server;
+  const originalHandler = rawServer._requestHandlers.get("tools/list");
+  if (!originalHandler) return;
+  rawServer.setRequestHandler(ListToolsRequestSchema, async (request, extra) => {
+    const result = await originalHandler(request, extra);
+    for (const tool of result.tools ?? []) {
+      if (tool.inputSchema?.$schema) tool.inputSchema.$schema = JSON_SCHEMA_2020_12;
+      if (tool.outputSchema?.$schema) tool.outputSchema.$schema = JSON_SCHEMA_2020_12;
+    }
+    return result;
+  });
+}
+
 export function createYnabServer(options = {}) {
 
 const {
@@ -3929,6 +3957,8 @@ const YNAB_PROMPTS = [
 for (const [slug, description, text] of YNAB_PROMPTS) {
   server.registerPrompt(slug, { title: slug.replace(/-/g, " "), description }, promptText(text));
 }
+
+fixListToolsSchemaDialect(server);
 
 return {
   server,


### PR DESCRIPTION
## Summary
- Every MCP tool call was failing before any handler ran, with errors like:
  `Tool '<name>' has an invalid outputSchema: JSON Schema declares an unsupported dialect ("$schema": "http://json-schema.org/draft-07/schema#"). The default validator supports JSON Schema 2020-12 only...`
- Root cause: the installed `@modelcontextprotocol/sdk` (1.29-1.30) converts zod tool schemas to JSON Schema in its `tools/list` handler without passing a dialect `target`, so it always defaults to draft-7 — regardless of what the server declares. This repo never wrote `$schema` anywhere; it's generated by the SDK per-request.
- Since the SDK exposes no public option to control the target dialect, and its server-side output validation uses zod directly (not Ajv, so there was nothing to reconfigure there either), the fix rewrites the SDK's `tools/list` response after the fact: `fixListToolsSchemaDialect()` wraps the low-level server's `tools/list` handler and rewrites `$schema` from draft-07 to `https://json-schema.org/draft/2020-12/schema` on each tool's input/output schema. This is safe because the generated schema bodies (`type`/`properties`/`required`/`additionalProperties`) are valid under both dialects — only the declared dialect string was wrong.

## Test plan
- [x] Instrumented `tools/list` output directly: confirmed `$schema` now reads `https://json-schema.org/draft/2020-12/schema`.
- [x] Called `ynab_auth_status` through a real MCP `Client` over stdio — call succeeds, `structuredContent` validates against the corrected schema.
- [x] `npm run smoke:list-tools` passes (38 tools listed).
- [x] `npm run test:unit` — 45/45 pass.
- [x] `npm run test:safety` passes.